### PR TITLE
fixed path for river data to be compliant with cloud loc

### DIFF
--- a/code/dev/read_hydroshed_riv_data.R
+++ b/code/dev/read_hydroshed_riv_data.R
@@ -3,7 +3,7 @@
 
 library(sf)
 
-data_loc <- "./data/HydroSHED/"
+data_loc <- "./data/raw/hydrosheds/"
 product <- "HydroSHEDS_RIV/"
 resolution <- "RIV_30s/"
 region <- "eu_riv_30s/"


### PR DESCRIPTION
Fixed path to data folder structure used in owncloud folder instead of downloaded folder structure from hydroSHED